### PR TITLE
Don't send serialized instance variables to squash. We were hitting a…

### DIFF
--- a/lib/squash_repeater/squash_ruby.rb
+++ b/lib/squash_repeater/squash_ruby.rb
@@ -15,5 +15,9 @@ module Squash::Ruby
     def http_transmit(url, headers, body)
       SquashRepeater.capture_exception(url: url, headers: headers, body: body, squash_configuration: @configuration, no_proxy_env: ENV["no_proxy"])
     end
+
+    def instance_variable_hash(object)
+      nil
+    end
   end
 end


### PR DESCRIPTION
…n error where a #to_json call on a REXML object would cause a stack overflow
