### PR TITLE
Prevent Timeout::Error from bubbling up

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    squash_repeater (0.1.12)
-      backburner (~> 1.0)
+    squash_repeater (0.1.13)
+      backburner (= 1.0)
       squash_ruby (~> 2.0)
       thor (~> 0.19)
 
@@ -49,7 +49,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    squash_ruby (2.0.0)
+    squash_ruby (2.0.1)
       json
     thor (0.19.1)
 
@@ -63,3 +63,6 @@ DEPENDENCIES
   rspec (~> 3.2)
   simplecov (~> 0.10)
   squash_repeater!
+
+BUNDLED WITH
+   1.11.2

--- a/lib/squash_repeater/exception_queue.rb
+++ b/lib/squash_repeater/exception_queue.rb
@@ -97,8 +97,8 @@ module SquashRepeater
         # Transmit it to the Squash server:
         Squash::Ruby.http_transmit__original(url, headers, body)
 
-      rescue SocketError => e
-        SquashRepeater.failsafe_handler(e, message: "whilst trying to connect to Squash", time_start: start)
+      rescue Timeout::Error, SocketError => e
+        SquashRepeater.failsafe_handler(e, message: "whilst trying to connect/transmit to Squash", time_start: start)
         raise
       end
     end

--- a/lib/squash_repeater/version.rb
+++ b/lib/squash_repeater/version.rb
@@ -1,3 +1,3 @@
 module SquashRepeater
-  VERSION = "0.1.12"
+  VERSION = "0.1.13"
 end

--- a/squash_repeater-ruby.gemspec
+++ b/squash_repeater-ruby.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-byebug", "~> 3.1"
 
   spec.add_runtime_dependency "squash_ruby", "~> 2.0"
-  spec.add_runtime_dependency "backburner", "~> 1.0"
+  spec.add_runtime_dependency "backburner", "1.0"
   spec.add_runtime_dependency "thor", "~> 0.19"
 end


### PR DESCRIPTION
Prevent Timeout::Error from bubbling up out of http_transmit__original and looking like a different cause.
