### PR TITLE
Make squash_repeater compatible with Ruby 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+gem 'squash_ruby', git: 'https://github.com/fluxfederation/SquareSquash-ruby.git'
+
 # Specify your gem's dependencies in squash_repeater-ruby.gemspec
 gemspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,15 @@
+GIT
+  remote: https://github.com/fluxfederation/SquareSquash-ruby.git
+  revision: 26f6eebdc3e68a5eb3375b805cf8bd1ee27e3463
+  specs:
+    squash_ruby (2.0.1.1)
+      json
+
 PATH
   remote: .
   specs:
     squash_repeater (0.1.19)
       backburner (= 1.0)
-      squash_ruby (~> 2.0)
       thor (~> 0.19)
 
 GEM
@@ -49,9 +55,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    squash_ruby (2.0.1)
-      json
-    thor (0.19.4)
+    thor (0.20.3)
 
 PLATFORMS
   ruby
@@ -63,6 +67,7 @@ DEPENDENCIES
   rspec (~> 3.2)
   simplecov (~> 0.10)
   squash_repeater!
+  squash_ruby!
 
 BUNDLED WITH
-   1.14.5
+   1.15.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
     dante (0.2.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    json (1.8.3)
+    json (1.8.6)
     method_source (0.8.2)
     pry (0.10.1)
       coderay (~> 1.1.0)

--- a/squash_repeater-ruby.gemspec
+++ b/squash_repeater-ruby.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "~> 0.10"
   spec.add_development_dependency "pry-byebug", "~> 3.1"
 
-  spec.add_runtime_dependency "squash_ruby", "~> 2.0"
   spec.add_runtime_dependency "backburner", "= 1.0"
   spec.add_runtime_dependency "thor", "~> 0.19"
 end


### PR DESCRIPTION
We need to use json gem 1.8.5 or higher, 1.8.3 fails to compile under 2.4
This commit bumps the json version to 1.8.6 and requires squash_ruby
from Flux Federation's github repo instead of from rubygems because
we need our custom modification for squash_ruby to work under 2.4 too.